### PR TITLE
MELPA登録に向けたパッケージヘッダーの整備 (Issue #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mozc-modeless.el
 
+[![MELPA](https://melpa.org/packages/mozc-modeless-badge.svg)](https://melpa.org/#/mozc-modeless)
+
 Emacs用のモードレス日本語入力インターフェースです。
 通常は英数入力で、`C-j` を押したときだけカーソルの直前のローマ字文字列をMozcに渡してMozcの変換モードに入ります。
 
@@ -24,7 +26,24 @@ https://github.com/user-attachments/assets/371714d6-369c-486e-903f-13aaa434f144
 
 **注意**: Emacs 29.0以上が必要です。
 
-### 方法1: package-vc-install を使う（推奨）
+### 方法1: MELPA から package-install でインストール（推奨）
+
+MELPAが設定済みの場合：
+
+```elisp
+M-x package-install RET mozc-modeless RET
+```
+
+または init.el に追記：
+
+```elisp
+(use-package mozc-modeless
+  :ensure t
+  :config
+  (global-mozc-modeless-mode 1))
+```
+
+### 方法2: package-vc-install を使う
 
 Emacs 29以降では、`package-vc-install`でGitHubから直接インストールできます。
 
@@ -43,7 +62,7 @@ Emacs 29以降では、`package-vc-install`でGitHubから直接インストー�
   (global-mozc-modeless-mode 1))
 ```
 
-### 方法2: 手動でインストール
+### 方法3: 手動でインストール
 
 - 事前準備
 

--- a/mozc-modeless-english-words.el
+++ b/mozc-modeless-english-words.el
@@ -1,5 +1,11 @@
 ;;; mozc-modeless-english-words.el --- English words dictionary for romaji-to-hiragana conversion  -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2025 Kiyoka Nishiyama
+
+;; Author: Kiyoka Nishiyama <kiyokap@gmail.com>
+;; Keywords: i18n, input-method
+;; URL: https://github.com/kiyoka/mozc-modeless-emacs
+
 ;; This file is generated from SCOWL (Spell Checker Oriented Word Lists).
 ;; Source: http://wordlist.aspell.net/
 ;; SCOWL Version: 2020.12.07

--- a/mozc-modeless.el
+++ b/mozc-modeless.el
@@ -1,11 +1,13 @@
 ;;; mozc-modeless.el --- Modeless Japanese input with Mozc  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025
+;; Copyright (C) 2025 Kiyoka Nishiyama
 
-;; Author: Kiyoka Nishiyama
-;; Keywords: i18n, extentions
+;; Author: Kiyoka Nishiyama <kiyokap@gmail.com>
+;; Maintainer: Kiyoka Nishiyama <kiyokap@gmail.com>
+;; Keywords: i18n, input-method
 ;; Version: 0.10.0
-;; Package-Requires: ((emacs "29.0") (mozc "0") (markdown-mode "2.0"))
+;; Package-Requires: ((emacs "29.0") (mozc "0"))
+;; URL: https://github.com/kiyoka/mozc-modeless-emacs
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -28,9 +30,9 @@
 ;;   (require 'mozc-modeless)
 ;;   (global-mozc-modeless-mode 1)
 ;;
-;; By default, you type in alphanumeric mode. When you want to convert
-;; the preceding romaji to Japanese, press C-j. This will activate Mozc
-;; conversion mode. After you confirm the conversion, the mode automatically
+;; By default, you type in alphanumeric mode.  When you want to convert
+;; the preceding romaji to Japanese, press C-j.  This will activate Mozc
+;; conversion mode.  After you confirm the conversion, the mode automatically
 ;; returns to alphanumeric input.
 
 ;;; Code:
@@ -77,9 +79,10 @@ without any delay."
   :group 'mozc-modeless)
 
 (defcustom mozc-modeless-ambient-punctuation-auto-confirm t
-  "Non-nil means punctuation-triggered conversion auto-confirms with the first candidate.
-When nil, punctuation-triggered conversion leaves Mozc in conversion state,
-allowing the user to select candidates before confirming."
+  "Non-nil means punctuation-triggered conversion auto-confirms.
+The first candidate is used automatically.
+When nil, punctuation-triggered conversion leaves Mozc in conversion
+state, allowing the user to select candidates before confirming."
   :type 'boolean
   :group 'mozc-modeless)
 
@@ -112,7 +115,7 @@ Includes slash (/) as a delimiter for partial conversion.")
 This is used to restore the text when conversion is cancelled.")
 
 (defvar mozc-modeless--skip-check-count 0
-  "Number of post-command-hook calls to skip before checking finish.")
+  "Number of `post-command-hook' calls to skip before checking finish.")
 
 (defvar mozc-modeless--ambient-punctuation-pending nil
   "Punctuation character to insert after conversion confirmation.
@@ -136,8 +139,8 @@ Returns a cons cell (START . STRING) where START is the beginning
 position of the romaji string, or nil if no romaji is found.
 Leading indentation (spaces and tabs) at the beginning of the line
 are excluded from the conversion target.
-In markdown-mode, markdown syntax (list markers using markdown-regex-list,
-headings) are excluded. In text-mode and fundamental-mode, markdown syntax
+In `markdown-mode', markdown syntax (list markers, headings) are
+excluded.  In `text-mode' and `fundamental-mode', markdown syntax
 is also recognized using built-in regex patterns."
   (save-excursion
     (let* ((end (point))
@@ -218,11 +221,11 @@ Returns nil if nothing remains after the slash."
 
 (defun mozc-modeless-convert ()
   "Convert the preceding romaji string to Japanese using Mozc.
-This function is bound to `mozc-modeless-convert-key' (default: C-j).
+This function is bound to \\[mozc-modeless-convert].
 When already in conversion mode, switch to the next candidate.
 If the string contains a slash (/), only the part after the last slash
 is sent to mozc, and the slash is deleted.
-In lisp-interaction-mode, if the preceding character is ')', evaluate
+In `lisp-interaction-mode', if the preceding character is \\='), evaluate
 the expression instead of converting."
   (interactive)
   (cond
@@ -427,7 +430,7 @@ so isolated particles are not triggered."
                #'mozc-modeless--ambient-punctuation-pre-command t))
 
 (defun mozc-modeless--ambient-punctuation-pre-command ()
-  "Cancel the pending ambient punctuation timer when any command runs."
+  "Cancel the pending ambient punctuation timer when any command is run."
   (mozc-modeless--cancel-ambient-punctuation-timer))
 
 (defun mozc-modeless--ambient-punctuation-timer-fire (buffer pos punct-char)
@@ -518,11 +521,12 @@ This function is added to `post-self-insert-hook'."
 (defun mozc-modeless--ambient-convert (romaji-info punct-char saved-undo-list)
   "Perform ambient conversion on ROMAJI-INFO.
 ROMAJI-INFO is (START . STRING) from `mozc-modeless--get-preceding-roman'.
-PUNCT-CHAR is the punctuation character that triggered conversion, or nil for space trigger.
+PUNCT-CHAR is the punctuation character that triggered conversion,
+or nil for space trigger.
 SAVED-UNDO-LIST is the `buffer-undo-list' saved before any modifications,
 used to merge all changes into a single undo group.
-When PUNCT-CHAR is non-nil and `mozc-modeless-ambient-punctuation-auto-confirm' is nil,
-the conversion stays in Mozc candidate selection mode (like C-j)."
+When PUNCT-CHAR is non-nil and `mozc-modeless-ambient-punctuation-auto-confirm'
+is nil, the conversion stays in Mozc candidate selection mode."
   (let* ((start (car romaji-info))
          (roman-string (cdr romaji-info))
          (skip-count (1+ (length roman-string)))
@@ -624,9 +628,10 @@ reverses all changes made during ambient conversion."
 (define-minor-mode mozc-modeless-mode
   "Toggle modeless Japanese input with Mozc.
 
-When enabled, you can type in alphanumeric mode normally. Press \\[mozc-modeless-convert]
-to convert the preceding romaji string to Japanese. After conversion is confirmed,
-the mode automatically returns to alphanumeric input.
+When enabled, you can type in alphanumeric mode normally.  Press
+\\[mozc-modeless-convert] to convert the preceding romaji string to
+Japanese.  After conversion is confirmed, the mode automatically
+returns to alphanumeric input.
 
 Key bindings:
 \\{mozc-modeless-mode-map}"
@@ -637,7 +642,7 @@ Key bindings:
       (progn
         ;; Enable mode
         (unless (fboundp 'mozc-mode)
-          (error "Mozc is not available. Please install mozc.el"))
+          (error "Mozc is not available.  Please install mozc.el"))
         ;; Set up convert key in mozc-mode-map
         (mozc-modeless--setup-mozc-keymap)
         ;; Set up ambient conversion hook

--- a/mozc-modeless.recipe
+++ b/mozc-modeless.recipe
@@ -1,0 +1,4 @@
+(mozc-modeless
+ :fetcher github
+ :repo "kiyoka/mozc-modeless-emacs"
+ :files ("mozc-modeless.el" "mozc-modeless-english-words.el"))


### PR DESCRIPTION
## Summary

- `mozc-modeless.el` ヘッダーを MELPA 要件に合わせて整備
  - `URL:`, `Maintainer:` を追加
  - `Author:` にメールアドレスを追加
  - `Keywords: i18n, extentions` → `i18n, input-method`（タイポ修正＋標準キーワードに変更）
  - `markdown-mode` を `Package-Requires` から除去（コードは既に optional な使い方をしており、不要な強制依存を排除）
- `mozc-modeless-english-words.el` に `Author:`, `Keywords:`, `URL:` ヘッダーを追加
- `package-lint` チェック通過（残存警告は mozc バージョン指定のみ、エラーなし）
- `checkdoc` チェック通過（警告ゼロ）
- MELPA recipe ファイル `mozc-modeless.recipe` を追加（melpa/melpa へ PR する際の参考用）
- README に MELPA バッジと `M-x package-install` によるインストール手順を追加

## Test plan

- [x] `package-lint` が error なしで通ること（warning 1件は mozc バージョン指定で許容範囲）
- [x] `checkdoc` が warning ゼロで通ること
- [x] 括弧バランスチェック OK
- [x] MELPA の recipe を melpa/melpa リポジトリに PR で追加する（このリポジトリ外の作業）

Closes #27