### PR TITLE
アンビエント変換（自動変換）をデフォルトで有効にする (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ MELPA以外のインストール方法は [付録: その他のインストー�
 
 ### アンビエント変換（自動変換）
 
-助詞＋スペースや句読点の入力をトリガーに、自動的にmozc変換を実行する機能です。Mozcの第1候補で自動確定し、タイピングの流れを中断しません。デフォルトは無効です。
-この設定が有能なときでも、C-jでの明示的な変換は可能です。
+助詞＋スペースや句読点の入力をトリガーに、自動的にmozc変換を実行する機能です。Mozcの第1候補で自動確定し、タイピングの流れを中断しません。デフォルトは有効です。
+この設定が有効なときでも、C-jでの明示的な変換は可能です。
 
 ```elisp
-;; 有効化
-(setq mozc-modeless-ambient-enable t)
+;; 無効化（C-jによる明示的な変換のみを使う場合）
+(setq mozc-modeless-ambient-enable nil)
 ```
 
 ```
@@ -91,7 +91,7 @@ MELPA以外のインストール方法は [付録: その他のインストー�
 
 | 変数 | デフォルト | 説明 |
 |------|-----------|------|
-| `mozc-modeless-ambient-enable` | `nil` | アンビエント変換の有効/無効 |
+| `mozc-modeless-ambient-enable` | `t` | アンビエント変換の有効/無効 |
 | `mozc-modeless-ambient-particles` | `("wa" "ha" "ga" ...)` | 変換トリガーとなる助詞リスト |
 | `mozc-modeless-ambient-punctuation` | `("." "," "?")` | 変換トリガーとなる句読点リスト |
 | `mozc-modeless-ambient-punctuation-auto-confirm` | `t` | `t`: 句読点入力時に第1候補で自動確定 / `nil`: 候補選択モードで止まる |

--- a/mozc-modeless.el
+++ b/mozc-modeless.el
@@ -52,10 +52,12 @@
   :type 'key-sequence
   :group 'mozc-modeless)
 
-(defcustom mozc-modeless-ambient-enable nil
+(defcustom mozc-modeless-ambient-enable t
   "Non-nil to enable ambient (automatic) conversion.
 When enabled, typing a particle followed by space or punctuation
-automatically triggers Mozc conversion."
+automatically triggers Mozc conversion.
+Set this to nil to disable ambient conversion and rely solely on
+the explicit conversion key (see `mozc-modeless-convert-key')."
   :type 'boolean
   :group 'mozc-modeless)
 


### PR DESCRIPTION
## 概要

Issue #35 への対応。アンビエント変換（自動変換）のデフォルト値を無効（`nil`）から有効（`t`）に変更し、`mozc-modeless-mode` を有効にしただけで自動変換が動作するようにします。

## 変更内容

- **`mozc-modeless.el`**
  - `mozc-modeless-ambient-enable` のデフォルトを `nil` → `t` に変更
  - docstring に無効化方法（`(setq mozc-modeless-ambient-enable nil)`）を追記
  - Version: `0.9.0` → `0.10.0`（挙動が変わる破壊的変更）
- **`README.md`**
  - 「デフォルトは無効」→「デフォルトは有効」に修正
  - サンプルコードを「有効化」から「無効化」に変更
  - カスタマイズ変数表のデフォルト値を `nil` → `t` に修正

## 互換性についての注意

既存ユーザーにとっては挙動が変わる破壊的変更です。C-j による明示的な変換のみを使いたい場合は、以下で従来の挙動に戻せます。

```elisp
(setq mozc-modeless-ambient-enable nil)
```

英文検出（英単語率80%以上）と除外モード（`shell-mode` 等）により、デフォルト有効でも誤変換が起きにくいよう配慮済みです。

## 検証

- `agent-lisp-paren-aid-linux mozc-modeless.el`: ok
- `emacs --batch -f batch-byte-compile`（mozc スタブ環境）: 警告なしでコンパイル成功

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
